### PR TITLE
Update to 1.3.13

### DIFF
--- a/build/root.build
+++ b/build/root.build
@@ -1,6 +1,7 @@
 cxx.std = latest
 
 using cxx
+using in
 
 hxx{*}: extension = h
 cxx{*}: extension = cpp

--- a/manifest
+++ b/manifest
@@ -1,6 +1,6 @@
 : 1
 name: redis-plus-plus
-version: 1.3.3+1
+version: 1.3.13+1
 summary: Redis client written in C++
 license: Apache-2.0
 url: https://github.com/sewenew/redis-plus-plus

--- a/redis-plus-plus/buildfile
+++ b/redis-plus-plus/buildfile
@@ -23,11 +23,11 @@ if ($cxx.target.class == 'linux')
     cxx.libs =+ "-lpthread"
 }
 
-cxx.poptions =+ "-I$src_base/src" "-I$src_base/src/sw/redis++" "-I$src_base/src/sw/redis++/cxx17/sw/redis++" "-I$src_base/src/sw/redis++/tls/sw/redis++" "-I$src_base/src/sw/redis++/future/std/sw/redis++"
+cxx.poptions =+ "-I$out_base/src" "-I$out_base/src/sw/redis++" "-I$src_base/src" "-I$src_base/src/sw/redis++" "-I$src_base/src/sw/redis++/cxx17/sw/redis++" "-I$src_base/src/sw/redis++/tls/sw/redis++" "-I$src_base/src/sw/redis++/future/std/sw/redis++"
 
 lib{redis-plus-plus}:
 {
-  cxx.export.poptions += "-I$src_base/src" "-I$src_base/src/sw/redis++" "-I$src_base/src/sw/redis++/cxx17/sw/redis++" "-I$src_base/src/sw/redis++/tls/sw/redis++" "-I$src_base/src/sw/redis++/future/std/sw/redis++"
+  cxx.export.poptions += "-I$out_base/src" "-I$out_base/src/sw/redis++" "-I$src_base/src" "-I$src_base/src/sw/redis++" "-I$src_base/src/sw/redis++/cxx17/sw/redis++" "-I$src_base/src/sw/redis++/tls/sw/redis++" "-I$src_base/src/sw/redis++/future/std/sw/redis++"
   cxx.export.libs += $libs
 }
 

--- a/redis-plus-plus/buildfile
+++ b/redis-plus-plus/buildfile
@@ -2,13 +2,16 @@ import libs = hiredis%lib{hiredis-ssl}
 
 lib{redis-plus-plus}: libul{redis-plus-plus}: \
     src/sw/redis++/{cxx hxx}{command command_options connection connection_pool errors pipeline redis redis_cluster reply sentinel shards shards_pool subscriber transaction} \
-    src/sw/redis++/cxx17/hxx{cxx_utils} \
-    src/sw/redis++/tls/{cxx hxx}{tls} \
+    src/sw/redis++/cxx17/sw/redis++/hxx{cxx_utils} \
+    src/sw/redis++/tls/sw/redis++/{cxx hxx}{tls} \
+    src/sw/redis++/future/std/sw/redis++/{hxx}{async_utils} \
     src/sw/redis++/cxx{crc16} \
-    src/sw/redis++/hxx{queued_redis queued_redis.hpp redis.hpp redis_cluster.hpp utils redis++ cmd_formatter command_args} \
+    src/sw/redis++/hxx{queued_redis queued_redis.hpp redis.hpp redis_cluster.hpp utils redis++ cmd_formatter command_args hiredis_features} \
     $libs
 lib{redis-plus-plus}: def{redis-plus-plus}: include = ($cxx.target.system == 'win32-msvc')
 def{redis-plus-plus}: libul{redis-plus-plus}
+
+hxx{src/sw/redis++/hiredis_features}: in{hiredis_features}
 
 if ($cxx.target.class == 'windows')
 {
@@ -20,11 +23,11 @@ if ($cxx.target.class == 'linux')
     cxx.libs =+ "-lpthread"
 }
 
-cxx.poptions =+ "-I$src_base/src" "-I$src_base/src/sw/redis++" "-I$src_base/src/sw/redis++/cxx17" "-I$src_base/src/sw/redis++/tls"
+cxx.poptions =+ "-I$src_base/src" "-I$src_base/src/sw/redis++" "-I$src_base/src/sw/redis++/cxx17/sw/redis++" "-I$src_base/src/sw/redis++/tls/sw/redis++" "-I$src_base/src/sw/redis++/future/std/sw/redis++"
 
 lib{redis-plus-plus}:
 {
-  cxx.export.poptions += "-I$src_base/src" "-I$src_base/src/sw/redis++" "-I$src_base/src/sw/redis++/cxx17" "-I$src_base/src/sw/redis++/tls"
+  cxx.export.poptions += "-I$src_base/src" "-I$src_base/src/sw/redis++" "-I$src_base/src/sw/redis++/cxx17/sw/redis++" "-I$src_base/src/sw/redis++/tls/sw/redis++" "-I$src_base/src/sw/redis++/future/std/sw/redis++"
   cxx.export.libs += $libs
 }
 
@@ -34,13 +37,19 @@ src/hxx{*}:
     install.subdirs = true
 }
 
-src/sw/redis++/cxx17/hxx{*}:
+src/sw/redis++/cxx17/sw/redis++/hxx{*}:
 {
     install = include/sw/redis++/
     install.subdirs = false
 }
 
-src/sw/redis++/tls/hxx{*}:
+src/sw/redis++/tls/sw/redis++/hxx{*}:
+{
+    install = include/sw/redis++/
+    install.subdirs = false
+}
+
+src/sw/redis++/future/std/sw/redis++/hxx{*}:
 {
     install = include/sw/redis++/
     install.subdirs = false

--- a/redis-plus-plus/hiredis_features.h.in
+++ b/redis-plus-plus/hiredis_features.h.in
@@ -1,5 +1,4 @@
-/*
- * TODO: find a way to properly set that define.
- * It should be enabled when hiredis.h defines a function named redisEnableKeepAliveWithInterval
-#define REDIS_PLUS_PLUS_HAS_redisEnableKeepAliveWithInterval
-*/
+#include <hiredis/hiredis.h>
+#if HIREDIS_MAJOR == 1 && HIREDIS_MINOR >= 2
+# define REDIS_PLUS_PLUS_HAS_redisEnableKeepAliveWithInterval
+#endif

--- a/redis-plus-plus/hiredis_features.h.in
+++ b/redis-plus-plus/hiredis_features.h.in
@@ -1,0 +1,5 @@
+/*
+ * TODO: find a way to properly set that define.
+ * It should be enabled when hiredis.h defines a function named redisEnableKeepAliveWithInterval
+#define REDIS_PLUS_PLUS_HAS_redisEnableKeepAliveWithInterval
+*/


### PR DESCRIPTION
Hi !

Redis-plus-plus currently does not build, due to an issue that was fixed in version 1.3.8. However, a few things have changed since the last time this was wrapped in a build2 package, and it needs an update to support the latest versions.

#### Quick note about the REDIS_PLUS_PLUS_HAS_redisEnableKeepAliveWithInterval define
The original package uses a CMake feature called `CheckSymbolExist` to figure out whether the Hiredis header defines a function named `redisEnableKeepAliveWithInterval`. It then uses an `in` file, using `#cmakedefine` to let its own header knows about the existence of said function.

I would be so bold as to say that this is NOT the way, and maybe upstream should consider changing that... but for the time being, since build2 does not have a `CheckSymbolExist` thing, I was forced to do it the right way: this is why this pull request adds an `hiredis_features.h` header, which is then non-intrusively included into the project's source using the `in` module. This header uses the version define of Hiredis to determine whether the function exists or not. I checked the releases of Hiredis, and the function was introduced in version 1.2.0.